### PR TITLE
walkingkooka-spreadsheet-dominokit gwt

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/server/platform/JettyHttpServerSpreadsheetHttpServer2.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/platform/JettyHttpServerSpreadsheetHttpServer2.java
@@ -28,7 +28,7 @@ public final class JettyHttpServerSpreadsheetHttpServer2 {
                         "localhost",
                         "12345",
                         "EN-GB",
-                        "./src/main/resources"
+                        "./target/classes" // walkingkooka-spreadsheet-domino will place its files here.
                 }
         );
     }


### PR DESCRIPTION
- Updated JettyHttpServerSpreadsheetHttpServer2 to serve the output of the codeserver from walkingkooka-spreadsheet-dominokit/gwt:codeserver