### PR TITLE
Swagger cell/*/find cell-range-path entries FIX

### DIFF
--- a/src/main/resources/api-doc/swagger.json
+++ b/src/main/resources/api-doc/swagger.json
@@ -1090,14 +1090,14 @@
             "schema": {
               "type": "string",
               "enum": [
-                "lrtd",
-                "rltd",
-                "lrbu",
-                "rlbu",
-                "tdlr",
-                "tdrl",
-                "bulr",
-                "burl"
+                "LRTD",
+                "RLTD",
+                "LRBU",
+                "RLBU",
+                "TDLR",
+                "TDRL",
+                "BULR",
+                "BURL"
               ]
             }
           },


### PR DESCRIPTION
- Previous entries were lower-cased forms of the ENUM, and now have been upper-cased.